### PR TITLE
get task id from time.php instead of tasks.php

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,14 +29,15 @@ app.post('/track-time', function(request, response) {
           var projectIdEndOffset = projectsResponse.body.indexOf('"', projectIdOffset);
           var projectId = projectsResponse.body.substring(projectIdOffset+3, projectIdEndOffset);
           
-          http.get({ uri: serviceUri+'/tasks.php', jar: true },
+          http.get({ uri: serviceUri+'/time.php', jar: true },
             function(err, tasksResponse) {
 
-            var taskLabelOffset = tasksResponse.body.indexOf("<td>"+request.body.task+"</td>");
-            if(taskLabelOffset === -1) { response.status(400).send('invalid task name'); return; }
-            var taskIdOffset = tasksResponse.body.indexOf('id=', taskLabelOffset);
-            var taskIdEndOffset = tasksResponse.body.indexOf('"', taskIdOffset);
-            var taskId = tasksResponse.body.substring(taskIdOffset+3, taskIdEndOffset);
+            var r = new RegExp('^\\s+task_names\\[(\\d+)\\] = "' + request.body.task + '";$', 'm');
+            var tmp = tasksResponse.body.match(r);
+
+            if (tmp === null) { response.status(400).send('invalid task name'); return; }
+
+            var taskId = tmp[1];
 
             http.post({ uri: serviceUri+'/time.php', jar: true, form: {
                 project: projectId,


### PR DESCRIPTION
codemill-id-56f6ba037e64df030099d215 fixes #7

Okay, so I've verified this works on my end.  I'm none too happy that the original implementation and this essentially scrape text from HTML without interpreting the HTML first.  This works, but it's not any cleaner [or worse] than the original.

I had been exploring a better alternative where you create the actual DOM with the jsdom and jquery modules.  Then you would be able to "query" for the task id by traversing to the 3rd `<script>` of the page.

In short, traversing the source of a web page with a `.indexOf()` or a RegExp is just bad.

(I can work on this more if you like)
